### PR TITLE
improvement for Poedit

### DIFF
--- a/bin/x_gettext
+++ b/bin/x_gettext
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+
+out_file=$1
+shift 1
+
+extract.py $@
+
+xgettext --language=PHP --force-po -o $out_file --from-code=UTF-8 -k_ -kgettext $@
+
+msgcat --force-po -o "$out_file" "$out_file" "/tmp/hd_messages.po"

--- a/extract.py
+++ b/extract.py
@@ -110,7 +110,7 @@ def main():
     This is what ties it all together.
     """
     php_files = sys.argv[1:]
-    output_file = "hd_messages.po"
+    output_file = "/tmp/hd_messages.po"
     messages = []
     
     if DEBUG:

--- a/extract.py
+++ b/extract.py
@@ -125,6 +125,11 @@ def main():
     messages = list(set(messages))
     
     file_handle = open(output_file, 'w')
+    
+    file_handle.write("msgid \"\"\n")
+    file_handle.write("msgstr \"\"\n")
+    file_handle.write("\"Content-Type: text/plain; charset=UTF-8\\n\"\n")
+    
     for message in messages:
         if DEBUG:
             print(output_message_lines(message))


### PR DESCRIPTION
1st thanks for avesome script
with this improvement you can use this script directly from Poedit. file encoding and keywords hardcoded in x_gettext shell script, no time to writing complex script
settings in Poedit in screenshot: 
command to run parser: x_gettext %o %F
![snap](https://cloud.githubusercontent.com/assets/15909390/13031012/4a937972-d2bd-11e5-8fab-06335ab48a96.jpeg)
